### PR TITLE
Various improvements/fixes

### DIFF
--- a/keymaps/open-conemu-here.cson
+++ b/keymaps/open-conemu-here.cson
@@ -1,0 +1,2 @@
+'atom-workspace':
+  'ctrl-alt-shift-i': 'open-conemu-here:open-default'

--- a/lib/open-conemu-here.coffee
+++ b/lib/open-conemu-here.coffee
@@ -1,35 +1,57 @@
-exec = require("child_process").exec
+exec = require('child_process').exec
+process = require('process')
 path = require('path')
 fs = require('fs')
+{CompositeDisposable} = require 'atom'
 
 module.exports =
 
-  configDefaults: {
-    win32App: 'ConEmu64.exe'
-    win32Args: ''
-  },
+  config:
+    executablePath:
+      type: 'string'
+      default: 'ConEmu.exe'
+      description: 'Path to ConEmu.exe or ConEmu64.exe.'
+    extraArguments:
+      type: 'string'
+      default: ''
+      description: 'Additional arguments to apply.'
+
+  subscriptions: null
 
   activate: ->
-    atom.commands.add '.tree-view .selected',
-      'open-conemu-here:open': (event) => @open(event.currentTarget)
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      'open-conemu-here:open-default': => @open()
+    @subscriptions.add atom.commands.add '.tree-view .selected',
+      'open-conemu-here:open-target': (event) => @open(event.currentTarget)
+    @subscriptions.add atom.commands.add 'atom-text-editor',
+      'open-conemu-here:open-target': => @open()
+
+   deactivate: ->
+     @subscriptions.dispose()
 
   open: (target) ->
-    isWin32 = document.body.classList.contains("platform-win32")
+    if document.body.classList.contains("platform-win32")
 
-    filepath = target.getPath?() ? target.item?.getPath()
+      if target?
+        filepath = target.getPath?() ? target.item?.getPath() ? target
 
-    dirpath = filepath
+      else
+        filepath = atom.workspace.getActivePaneItem()?.buffer?.file?.getPath()
+        filepath ?= atom.project.getPaths()?[0]
 
-    if fs.lstatSync(filepath).isFile()
-      dirpath = path.dirname(filepath)
+      if filepath? and fs.lstatSync(filepath).isFile()
+        dirpath = path.dirname(filepath)
+      else
+        dirpath = filepath
 
-    return if not dirpath
+      return if not dirpath
 
-    if isWin32
-      @isWin32 dirpath
-
-
-  isWin32: (dirpath) ->
-    app = atom.config.get('open-conemu-here.win32App')
-    args = atom.config.get('open-conemu-here.win32Args')
-    exec "start #{app} /Dir \"#{dirpath}\" #{args}"
+      app = atom.config.get('open-conemu-here.executablePath')
+      args = atom.config.get('open-conemu-here.extraArguments')
+      env = {}
+      for key, val of process.env
+        env[key] = val
+      delete env['NODE_ENV'] # Workaround for https://github.com/atom/atom/issues/3099
+      exec "start #{app} /Dir \"#{dirpath}\" #{args}",
+        env: env

--- a/menus/open-conemu-here.cson
+++ b/menus/open-conemu-here.cson
@@ -1,0 +1,22 @@
+'context-menu':
+  '.tree-view.full-menu': [
+    {
+      'label': 'Open ConEmu Here'
+      'command': 'open-conemu-here:open-target'
+    }
+  ]
+  'atom-text-editor': [
+    'label': 'Open ConEmu Here'
+    'command': 'open-conemu-here:open-default'
+  ]
+'menu': [
+  {
+    'label': 'Packages'
+    'submenu': [
+      {
+        'label': 'Open ConEmu Here'
+        'command': 'open-conemu-here:open-default'
+      }
+    ]
+  }
+]

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -1,3 +1,0 @@
-'context-menu':
-  '.platform-win32 .tree-view':
-    'Open ConEmu Here': 'open-conemu-here:open'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.4.0",
   "description": "Adds a shortcut to Tree View - Open ConEmu Here in the context menu",
   "activationCommands ": [
-    "open-conemu-here:open"
+    "open-conemu-here:open-default",
+    "open-conemu-here:open-target"
   ],
   "repository": "https://github.com/ziyasal/atom-open-conemu-here",
   "author": "Ziya SARIKAYA <sarikayaziya@gmail.com> (http://github.com/ziyasal)",
@@ -14,7 +15,7 @@
   },
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.0.0 <2.0.0"
   },
   "keywords": [
     "terminal",


### PR DESCRIPTION
- Added `open-default` command (bound to key `ctrl-alt-shift-i`)
  - Opens ConEmu using the currently edited file, or if no files open, the first project directory, if present
- Use JSON Schema configuration (configurable through Settings panel)
- Clean up using subscriptions
- Workaround for `NODE_ENV` being set to production: https://github.com/atom/atom/issues/3099
